### PR TITLE
Revamp skill bar styling and add flipped-board avatar

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,6 +360,247 @@
   .skill-ready {
     animation: skill-ready-pulse 1.5s ease-in-out infinite;
   }
+
+  .skill-button {
+    background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 55%),
+                radial-gradient(circle at bottom right, rgba(147, 51, 234, 0.22), transparent 60%),
+                rgba(15, 23, 42, 0.82);
+    border-color: rgba(56, 189, 248, 0.35);
+    color: #f8fafc;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+    cursor: pointer;
+  }
+
+  .skill-button:hover:not([disabled]) {
+    transform: translateY(-2px) scale(1.01);
+    box-shadow: 0 18px 28px rgba(56, 189, 248, 0.25);
+  }
+
+  .skill-button:active:not([disabled]) {
+    transform: translateY(0) scale(0.995);
+  }
+
+  .skill-button-affordable {
+    border-color: rgba(56, 189, 248, 0.55);
+  }
+
+  .skill-button-active {
+    background: linear-gradient(135deg, rgba(251, 191, 36, 0.9), rgba(249, 115, 22, 0.9));
+    border-color: rgba(251, 191, 36, 0.8);
+    color: #0f172a;
+    box-shadow: 0 16px 32px rgba(249, 115, 22, 0.35), inset 0 0 12px rgba(255, 255, 255, 0.35);
+  }
+
+  .skill-button-active .skill-button-title {
+    color: #1f2937;
+    text-shadow: 0 0 12px rgba(251, 191, 36, 0.65);
+  }
+
+  .skill-button-active .skill-button-icon {
+    background: linear-gradient(135deg, rgba(251, 191, 36, 0.95), rgba(249, 115, 22, 0.9));
+    box-shadow: 0 0 14px rgba(249, 115, 22, 0.6);
+  }
+
+  .skill-button-active .skill-button-cost {
+    background: rgba(255, 247, 237, 0.85);
+    color: #92400e;
+    border-color: rgba(249, 115, 22, 0.7);
+    text-shadow: none;
+  }
+
+  .skill-button-active .skill-button-description {
+    color: rgba(30, 41, 59, 0.9);
+    text-shadow: none;
+  }
+
+  .skill-button-disabled,
+  .skill-button[disabled] {
+    background: rgba(51, 65, 85, 0.75);
+    border-color: rgba(71, 85, 105, 0.6);
+    color: #94a3b8;
+    cursor: not-allowed;
+    box-shadow: none;
+  }
+
+  .skill-button-glow {
+    position: absolute;
+    inset: -2px;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.38), rgba(147, 51, 234, 0.25));
+    opacity: 0.65;
+    filter: blur(1px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    pointer-events: none;
+  }
+
+  .skill-button:hover:not([disabled]) .skill-button-glow {
+    opacity: 0.9;
+    transform: scale(1.05);
+  }
+
+  .skill-button[disabled] .skill-button-glow {
+    opacity: 0.2;
+  }
+
+  .skill-button[disabled] .skill-button-title {
+    color: rgba(203, 213, 225, 0.75);
+    text-shadow: none;
+  }
+
+  .skill-button[disabled] .skill-button-icon {
+    background: rgba(148, 163, 184, 0.25);
+    box-shadow: none;
+    color: rgba(148, 163, 184, 0.8);
+  }
+
+  .skill-button[disabled] .skill-button-cost {
+    background: rgba(51, 65, 85, 0.85);
+    border-color: rgba(148, 163, 184, 0.4);
+    color: rgba(226, 232, 240, 0.6);
+    text-shadow: none;
+  }
+
+  .skill-button[disabled] .skill-button-description {
+    color: rgba(148, 163, 184, 0.85);
+    text-shadow: none;
+  }
+
+  .skill-button-inner {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    z-index: 1;
+  }
+
+  .skill-button-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .skill-button-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-weight: 800;
+    font-size: clamp(1rem, 1vw + 0.8rem, 1.35rem);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #f8fafc;
+    text-shadow:
+      0 0 6px rgba(56, 189, 248, 0.6),
+      0 0 14px rgba(99, 102, 241, 0.35);
+  }
+
+  .skill-button-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 9999px;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.7), rgba(14, 165, 233, 0.8));
+    box-shadow: 0 0 10px rgba(56, 189, 248, 0.5);
+    font-size: 0.95rem;
+  }
+
+  .skill-button-cost {
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 0.35rem 0.6rem;
+    border-radius: 9999px;
+    background: rgba(15, 23, 42, 0.65);
+    border: 1px solid rgba(251, 191, 36, 0.7);
+    color: #fef3c7;
+    text-shadow: 0 0 6px rgba(251, 191, 36, 0.6);
+  }
+
+  .skill-button-description {
+    font-size: 0.82rem;
+    line-height: 1.35;
+    color: rgba(226, 232, 240, 0.95);
+    text-shadow: 0 0 6px rgba(15, 23, 42, 0.7);
+  }
+
+  @media (max-width: 768px) {
+    .skill-button {
+      padding: 0.9rem;
+    }
+    .skill-button-title {
+      font-size: clamp(0.95rem, 4vw, 1.1rem);
+      letter-spacing: 0.05em;
+    }
+    .skill-button-cost {
+      font-size: 0.7rem;
+      padding: 0.25rem 0.5rem;
+    }
+    .skill-button-description {
+      font-size: 0.78rem;
+    }
+  }
+
+  .flipped-board-background {
+    position: absolute;
+    inset: 0;
+    background-image:
+      radial-gradient(circle at 30% 25%, rgba(79, 70, 229, 0.25), transparent 55%),
+      radial-gradient(circle at 70% 70%, rgba(14, 165, 233, 0.2), transparent 60%),
+      url('/assets/张呈.png');
+    background-size: cover;
+    background-position: center 20%;
+    filter: saturate(1.05) contrast(1.05);
+    opacity: 0.55;
+  }
+
+  .flipped-avatar-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+  }
+
+  .flipped-avatar-frame {
+    position: relative;
+    width: clamp(120px, 35%, 220px);
+    aspect-ratio: 1 / 1;
+    border-radius: 9999px;
+    border: 3px solid rgba(255, 255, 255, 0.65);
+    overflow: hidden;
+    background: rgba(15, 23, 42, 0.55);
+    box-shadow:
+      0 0 35px rgba(14, 165, 233, 0.35),
+      0 0 55px rgba(99, 102, 241, 0.3);
+  }
+
+  .flipped-avatar-glow {
+    position: absolute;
+    inset: -15%;
+    background: radial-gradient(circle, rgba(56, 189, 248, 0.45), transparent 70%);
+    filter: blur(12px);
+    opacity: 0.85;
+  }
+
+  .flipped-avatar-image {
+    position: absolute;
+    inset: 8%;
+    background-image: url('/assets/张呈.png');
+    background-size: cover;
+    background-position: center 12%;
+    border-radius: inherit;
+    filter: saturate(1.15) drop-shadow(0 12px 18px rgba(15, 23, 42, 0.55));
+  }
+
+  @media (max-width: 768px) {
+    .flipped-avatar-frame {
+      width: clamp(90px, 45vw, 160px);
+    }
+    .flipped-board-background {
+      opacity: 0.6;
+    }
+  }
   
   /* Epic Title Effect - Brush Calligraphy Style */
   @keyframes title-glow {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1065,15 +1065,14 @@ const App: React.FC = () => {
   };
   
   const getSkillButtonClass = (skill: Skill) => {
-    const baseClass = "w-full text-left p-2.5 rounded-lg transition-all duration-200 shadow-md border-b-4 relative overflow-hidden";
-    const disabledClass = "bg-slate-600 border-slate-700 text-slate-400 cursor-not-allowed opacity-60";
-    const activeClass = "bg-amber-500 border-amber-700 text-black transform scale-105 shadow-lg ring-2 ring-white";
-    const hoverClass = "hover:bg-sky-600 hover:border-sky-800 hover:scale-105";
-    const affordableClass = "bg-sky-700/80 border-sky-900 backdrop-blur-sm skill-ready";
+    const baseClass = "w-full text-left p-2.5 rounded-lg transition-all duration-200 shadow-md border-b-4 relative overflow-hidden skill-button group";
+    const disabledClass = "skill-button-disabled";
+    const activeClass = "skill-button-active";
+    const affordableClass = "skill-button-affordable skill-ready";
 
     if (humanScore < skill.cost) return `${baseClass} ${disabledClass}`;
     if (activeSkill === skill.id || skillState?.skill === skill.id) return `${baseClass} ${activeClass}`;
-    return `${baseClass} ${affordableClass} ${hoverClass}`;
+    return `${baseClass} ${affordableClass}`;
   };
 
   const getDanmakuColorClass = (speaker: string) => {
@@ -1293,11 +1292,17 @@ const App: React.FC = () => {
                       disabled={humanScore < skill.cost || !!skillToAnimate || !!aiSkillToAnimate}
                       className={getSkillButtonClass(skill) + ' mobile-skill-btn'}
                   >
-                      <div className="flex justify-between items-baseline relative z-10">
-                         <span className="font-bold text-sm md:text-base">⚡ {skill.name}</span>
-                         <span className="font-semibold text-xs bg-black/40 px-1.5 md:px-2 py-0.5 rounded border border-amber-400/50">消耗 {skill.cost}</span>
+                      <div className="skill-button-glow" aria-hidden="true"></div>
+                      <div className="skill-button-inner">
+                        <div className="skill-button-header">
+                          <span className="skill-button-title">
+                            <span className="skill-button-icon" aria-hidden="true">⚡</span>
+                            {skill.name}
+                          </span>
+                          <span className="skill-button-cost">消耗 {skill.cost}</span>
+                        </div>
+                        <p className="skill-button-description">{skill.description}</p>
                       </div>
-                      <p className="text-xs text-slate-200 mt-0.5 md:mt-1 relative z-10 leading-tight">{skill.description}</p>
                   </button>
               ))}
            </div>

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -179,20 +179,20 @@ const Board: React.FC<BoardProps> = ({
             border: '3px solid #A0826D',
             boxShadow: 'inset 0 0 10px rgba(0, 0, 0, 0.1)'
           }}>
-            {/* Background Image */}
-            <div 
-              className="absolute inset-0 bg-cover bg-center"
-              style={{ 
-                backgroundImage: 'url(/assets/张呈.png)',
-                backgroundPosition: 'center 20%',
-                opacity: 0.6,
-                backgroundColor: '#F5E6D3'
-              }}
-            ></div>
-            
+            {/* Background Illustration */}
+            <div className="flipped-board-background" aria-hidden="true"></div>
+
+            {/* Avatar spotlight */}
+            <div className="flipped-avatar-overlay" aria-hidden="true">
+              <div className="flipped-avatar-frame">
+                <div className="flipped-avatar-glow"></div>
+                <div className="flipped-avatar-image"></div>
+              </div>
+            </div>
+
             {/* Overlay for contrast */}
             <div className="absolute inset-0" style={{
-              background: 'rgba(245, 230, 211, 0.3)'
+              background: 'rgba(245, 230, 211, 0.28)'
             }}></div>
           </div>
           


### PR DESCRIPTION
## Summary
- redesign the skill buttons with glowing overlays, larger typography, and richer cost badges for better readability
- introduce dedicated CSS utilities to control active, disabled, and hover states of the skill list
- enhance the flipped board background with a centered avatar spotlight to emphasize the opponent’s presence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e61d7330b0832a93256192f16a5b96