### PR TITLE
Enhance skill panel typography and board flip avatar

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,6 +369,85 @@
   .skill-ready {
     animation: skill-ready-pulse 1.5s ease-in-out infinite;
   }
+
+  .skill-card {
+    background: linear-gradient(135deg, rgba(30, 64, 175, 0.9), rgba(76, 29, 149, 0.85));
+    border-image: linear-gradient(135deg, rgba(125, 211, 252, 0.8), rgba(253, 224, 71, 0.8)) 1;
+    position: relative;
+    overflow: hidden;
+  }
+  .skill-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top left, rgba(255,255,255,0.18), transparent 55%),
+                radial-gradient(circle at bottom right, rgba(14, 116, 144, 0.3), transparent 60%);
+    mix-blend-mode: screen;
+    pointer-events: none;
+  }
+  .skill-card::after {
+    content: "";
+    position: absolute;
+    top: -40%;
+    right: -20%;
+    width: 65%;
+    height: 160%;
+    background: linear-gradient(120deg, rgba(255,255,255,0.6), rgba(255,255,255,0));
+    transform: rotate(18deg);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+  .skill-card:hover::after {
+    opacity: 0.5;
+  }
+  .skill-header {
+    gap: 0.5rem;
+  }
+  .skill-name {
+    font-family: 'ZCOOL KuaiLe', 'Zhi Mang Xing', 'STKaiti', 'Microsoft YaHei', sans-serif;
+    font-size: clamp(1rem, 3vw, 1.4rem);
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    color: #fef3c7;
+    text-transform: none;
+    text-shadow: 0 0 6px rgba(14, 165, 233, 0.6), 0 0 18px rgba(59, 130, 246, 0.5);
+    -webkit-text-stroke: 1px rgba(8, 47, 73, 0.6);
+    paint-order: stroke fill;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+  .skill-cost {
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 0.3rem 0.65rem;
+    border-radius: 9999px;
+    background: linear-gradient(135deg, rgba(8, 47, 73, 0.9), rgba(30, 64, 175, 0.9));
+    border: 1px solid rgba(125, 211, 252, 0.7);
+    color: #e0f2fe;
+    box-shadow: 0 0 10px rgba(125, 211, 252, 0.45);
+  }
+  .skill-description {
+    font-size: 0.8rem;
+    line-height: 1.4;
+    color: #f8fafc;
+    text-shadow: 0 0 10px rgba(15, 118, 110, 0.35);
+  }
+  @media (max-width: 768px) {
+    .skill-name {
+      font-size: clamp(0.95rem, 4vw, 1.2rem);
+      letter-spacing: 0.06em;
+    }
+    .skill-cost {
+      font-size: 0.7rem;
+      padding: 0.25rem 0.55rem;
+    }
+    .skill-description {
+      font-size: 0.75rem;
+    }
+  }
   
   /* Epic Title Effect - Brush Calligraphy Style */
   @keyframes title-glow {

--- a/public/assets/player-avatar.svg
+++ b/public/assets/player-avatar.svg
@@ -1,0 +1,29 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="hairGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4b5563" />
+      <stop offset="100%" stop-color="#1f2937" />
+    </linearGradient>
+    <linearGradient id="skinGradient" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#f4d0b0" />
+      <stop offset="100%" stop-color="#e0a97a" />
+    </linearGradient>
+    <linearGradient id="robeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#9333ea" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="18" flood-color="rgba(15,23,42,0.4)" />
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="128" fill="#0f172a" />
+  <g filter="url(#shadow)">
+    <path d="M256 96c-64 0-108 52-108 124 0 64 44 116 108 116s108-52 108-116c0-72-44-124-108-124z" fill="url(#hairGradient)" />
+    <path d="M256 120c-54 0-82 45-82 101 0 56 28 101 82 101s82-45 82-101c0-56-28-101-82-101z" fill="url(#skinGradient)" />
+    <path d="M256 272c-88 0-152 64-152 156v24h304v-24c0-92-64-156-152-156z" fill="url(#robeGradient)" />
+    <path d="M256 272c-32 0-72 16-72 40 0 24 40 48 72 48s72-24 72-48c0-24-40-40-72-40z" fill="#1e1b4b" opacity="0.35" />
+  </g>
+  <circle cx="218" cy="216" r="18" fill="#1f2937" />
+  <circle cx="294" cy="216" r="18" fill="#1f2937" />
+  <path d="M224 272c12 12 32 20 32 20s20-8 32-20" stroke="#9f1239" stroke-width="12" stroke-linecap="round" fill="none" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1065,7 +1065,7 @@ const App: React.FC = () => {
   };
   
   const getSkillButtonClass = (skill: Skill) => {
-    const baseClass = "w-full text-left p-2.5 rounded-lg transition-all duration-200 shadow-md border-b-4 relative overflow-hidden";
+    const baseClass = "w-full text-left p-2.5 rounded-lg transition-all duration-200 shadow-md border-b-4 relative overflow-hidden skill-card";
     const disabledClass = "bg-slate-600 border-slate-700 text-slate-400 cursor-not-allowed opacity-60";
     const activeClass = "bg-amber-500 border-amber-700 text-black transform scale-105 shadow-lg ring-2 ring-white";
     const hoverClass = "hover:bg-sky-600 hover:border-sky-800 hover:scale-105";
@@ -1293,11 +1293,11 @@ const App: React.FC = () => {
                       disabled={humanScore < skill.cost || !!skillToAnimate || !!aiSkillToAnimate}
                       className={getSkillButtonClass(skill) + ' mobile-skill-btn'}
                   >
-                      <div className="flex justify-between items-baseline relative z-10">
-                         <span className="font-bold text-sm md:text-base">⚡ {skill.name}</span>
-                         <span className="font-semibold text-xs bg-black/40 px-1.5 md:px-2 py-0.5 rounded border border-amber-400/50">消耗 {skill.cost}</span>
+                      <div className="skill-header flex justify-between items-baseline relative z-10">
+                         <span className="skill-name">⚡ {skill.name}</span>
+                         <span className="skill-cost">消耗 {skill.cost}</span>
                       </div>
-                      <p className="text-xs text-slate-200 mt-0.5 md:mt-1 relative z-10 leading-tight">{skill.description}</p>
+                      <p className="skill-description text-xs text-slate-200 mt-0.5 md:mt-1 relative z-10 leading-tight">{skill.description}</p>
                   </button>
               ))}
            </div>

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -245,16 +245,18 @@ const Board: React.FC<BoardProps> = ({
               <div
                 className="absolute inset-0 bg-cover bg-center"
                 style={{
-                  backgroundImage: 'url(/assets/张呈.png)',
-                  backgroundPosition: 'center 20%',
-                  opacity: 0.6,
-                  filter: 'saturate(0.9)',
+                  backgroundImage: 'url(/assets/player-avatar.svg)',
+                  backgroundPosition: 'center 25%',
+                  opacity: 0.85,
+                  filter: 'drop-shadow(0 12px 24px rgba(15,23,42,0.45)) saturate(1.1)',
+                  mixBlendMode: 'multiply',
                 }}
               ></div>
               <div
                 className="absolute inset-0"
                 style={{
-                  background: 'rgba(245, 230, 211, 0.4)',
+                  background:
+                    'radial-gradient(circle at 50% 30%, rgba(255,255,255,0.55), rgba(245,230,211,0.3) 55%, rgba(148,116,84,0.45) 100%)',
                 }}
               ></div>
             </>


### PR DESCRIPTION
## Summary
- restyle the skill buttons with larger, high-contrast typography and decorative accents
- tag skill markup with semantic classes for the new styling treatments
- swap the board flip backdrop to a new player avatar illustration for added personality

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e61f63ed10832a9be5fed85f950f86